### PR TITLE
Don't scale line widths on zoom

### DIFF
--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -381,7 +381,7 @@ var Arrow = function Arrow(options) {
             y2 = this._y2 * zf,
             w = this._strokeWidth * 0.5;
 
-        var headSize = (this._strokeWidth * 5) + 9,
+        var headSize = (this._strokeWidth * 4) + 5,
             dx = x2 - x1,
             dy = y2 - y1;
 

--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -208,7 +208,7 @@ Line.prototype.drawShape = function drawShape() {
 
     var p = this.getPath(),
         strokeColor = this._strokeColor,
-        strokeW = this._getLineWidth() * this._zoomFraction;
+        strokeW = this._getLineWidth();
 
     this.element.attr({'path': p,
                        'stroke': strokeColor,
@@ -379,12 +379,11 @@ var Arrow = function Arrow(options) {
             y1 = this._y1 * zf,
             x2 = this._x2 * zf,
             y2 = this._y2 * zf,
-            w = this._strokeWidth * zf * 0.5;
+            w = this._strokeWidth * 0.5;
 
         var headSize = (this._strokeWidth * 5) + 9,
             dx = x2 - x1,
             dy = y2 - y1;
-        headSize = headSize * this._zoomFraction;
 
         var lineAngle = Math.atan(dx / dy);
         var f = (dy < 0 ? 1 : -1);
@@ -740,7 +739,7 @@ Rect.prototype.destroy = function destroy() {
 Rect.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        lineW = this._strokeWidth * this._zoomFraction;
+        lineW = this._strokeWidth;
 
     var f = this._zoomFraction,
         x = this._x * f,
@@ -1290,7 +1289,7 @@ Ellipse.prototype.updateShapeFromHandles = function updateShapeFromHandles(resiz
 Ellipse.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth * this._zoomFraction;
+        strokeW = this._strokeWidth;
 
     var f = this._zoomFraction,
         x = this._x * f,
@@ -1701,7 +1700,7 @@ Polygon.prototype.updateHandle = function updateHandle(handleIndex, x, y, shiftK
 Polygon.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth * this._zoomFraction;
+        strokeW = this._strokeWidth;
 
     var f = this._zoomFraction;
     var path = this.getPath();

--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -2060,7 +2060,7 @@ ShapeManager.prototype.getStrokeColor = function getStrokeColor() {
 };
 
 ShapeManager.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
-    strokeWidth = parseInt(strokeWidth, 10);
+    strokeWidth = parseFloat(strokeWidth, 10);
     this._strokeWidth = strokeWidth;
     var selected = this.getSelectedShapes();
     for (var s=0; s<selected.length; s++) {

--- a/index.html
+++ b/index.html
@@ -68,6 +68,8 @@
 		<div class="toolbar">
 			Stroke Width:
 			<select name="strokeWidth">
+				<option value="0.25">0.25</option>
+				<option value="0.5">0.5</option>
 				<option value="1">1</option>
 				<option value="2" selected="selected">2</option>
 				<option value="3">3</option>

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -167,7 +167,7 @@ $(function() {
     shapeManager.addShapeJson({"type": "Polygon",
                                "points": "329,271 295,314 295,365 333,432 413,400 452,350 432,292 385,256",
                                "strokeColor": "#ffffff",
-                               "strokeWidth": 3});
+                               "strokeWidth": 0.5});
 
     shapeManager.addShapeJson({"type": "Polyline",
                                "points": "29,71 95,14 95,65 33,132 113,100 152,50",

--- a/src/js/shapeManager.js
+++ b/src/js/shapeManager.js
@@ -259,7 +259,7 @@ ShapeManager.prototype.getStrokeColor = function getStrokeColor() {
 };
 
 ShapeManager.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
-    strokeWidth = parseInt(strokeWidth, 10);
+    strokeWidth = parseFloat(strokeWidth, 10);
     this._strokeWidth = strokeWidth;
     var selected = this.getSelectedShapes();
     for (var s=0; s<selected.length; s++) {

--- a/src/js/shapes/ellipse.js
+++ b/src/js/shapes/ellipse.js
@@ -333,7 +333,7 @@ Ellipse.prototype.updateShapeFromHandles = function updateShapeFromHandles(resiz
 Ellipse.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth * this._zoomFraction;
+        strokeW = this._strokeWidth;
 
     var f = this._zoomFraction,
         x = this._x * f,

--- a/src/js/shapes/line.js
+++ b/src/js/shapes/line.js
@@ -228,7 +228,7 @@ Line.prototype.drawShape = function drawShape() {
 
     var p = this.getPath(),
         strokeColor = this._strokeColor,
-        strokeW = this._getLineWidth() * this._zoomFraction;
+        strokeW = this._getLineWidth();
 
     this.element.attr({'path': p,
                        'stroke': strokeColor,
@@ -399,12 +399,11 @@ var Arrow = function Arrow(options) {
             y1 = this._y1 * zf,
             x2 = this._x2 * zf,
             y2 = this._y2 * zf,
-            w = this._strokeWidth * zf * 0.5;
+            w = this._strokeWidth * 0.5;
 
         var headSize = (this._strokeWidth * 5) + 9,
             dx = x2 - x1,
             dy = y2 - y1;
-        headSize = headSize * this._zoomFraction;
 
         var lineAngle = Math.atan(dx / dy);
         var f = (dy < 0 ? 1 : -1);

--- a/src/js/shapes/line.js
+++ b/src/js/shapes/line.js
@@ -401,7 +401,7 @@ var Arrow = function Arrow(options) {
             y2 = this._y2 * zf,
             w = this._strokeWidth * 0.5;
 
-        var headSize = (this._strokeWidth * 5) + 9,
+        var headSize = (this._strokeWidth * 4) + 5,
             dx = x2 - x1,
             dy = y2 - y1;
 

--- a/src/js/shapes/polygon.js
+++ b/src/js/shapes/polygon.js
@@ -229,7 +229,7 @@ Polygon.prototype.updateHandle = function updateHandle(handleIndex, x, y, shiftK
 Polygon.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth * this._zoomFraction;
+        strokeW = this._strokeWidth;
 
     var f = this._zoomFraction;
     var path = this.getPath();

--- a/src/js/shapes/rect.js
+++ b/src/js/shapes/rect.js
@@ -244,7 +244,7 @@ Rect.prototype.destroy = function destroy() {
 Rect.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        lineW = this._strokeWidth * this._zoomFraction;
+        lineW = this._strokeWidth;
 
     var f = this._zoomFraction,
         x = this._x * f,


### PR DESCRIPTION
This removes scaling of line-widths when you zoom. So, a 1px line will always appear 1px think, even when you zoom in or out a lot.

This would align shape-editor (and OMERO.figure) with the way that e.g. OMERO.iviewer handles line widths when zooming.
Otherwise, when you zoom out a lot, especially with big images, the lines can disappear which is an issue in Insight and also with Big Image support in figure.

E.g. comparing old and new behaviour on the test page when zooming out to 40%

![screen shot 2018-04-16 at 15 23 41](https://user-images.githubusercontent.com/900055/38814793-4888295a-418a-11e8-9b5a-48eabad3340d.png)
