### PR TITLE
Fill color

### DIFF
--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -2169,7 +2169,7 @@ ShapeManager.prototype.getFillOpacity = function getFillOpacity() {
 };
 
 ShapeManager.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
-    var fillOpacity = parseFloat(fillOpacity, 10);
+    fillOpacity = parseFloat(fillOpacity, 10);
     this._fillOpacity = fillOpacity;
     var selected = this.getSelectedShapes();
     for (var s=0; s<selected.length; s++) {

--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -1056,6 +1056,8 @@ var Ellipse = function Ellipse(options) {
 
     this._strokeColor = options.strokeColor;
     this._strokeWidth = options.strokeWidth || 2;
+    this._fillColor = options.fillColor;
+    this._fillOpacity = options.fillOpacity;
     this._selected = false;
     this._zoomFraction = 1;
     if (options.zoom) {
@@ -1064,8 +1066,8 @@ var Ellipse = function Ellipse(options) {
     this.handle_wh = 6;
 
     this.element = this.paper.ellipse();
-    this.element.attr({'fill-opacity': 0.01,
-                        'fill': '#fff',
+    this.element.attr({'fill-opacity':  this._fillOpacity,
+                        'fill': this._fillColor,
                         'cursor': 'pointer'});
 
     // Drag handling of ellipse
@@ -1122,7 +1124,9 @@ Ellipse.prototype.toJson = function toJson() {
         'radiusY': this._radiusY,
         'rotation': this._rotation,
         'strokeWidth': this._strokeWidth,
-        'strokeColor': this._strokeColor
+        'strokeColor': this._strokeColor,
+        'fillColor': this._fillColor,
+        'fillOpacity':this._fillOpacity
     };
     if (this._id) {
         rv.id = this._id;
@@ -1190,10 +1194,23 @@ Ellipse.prototype.getStrokeWidth = function getStrokeWidth() {
     return this._strokeWidth;
 };
 
+Ellipse.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    this.drawShape();
+};
+
 Ellipse.prototype.getFillColor = function getFillColor() {
     return this._fillColor;
 };
 
+Ellipse.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    this._fillOpacity = fillOpacity;
+    this.drawShape();
+};
+
+Ellipse.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
+};
 
 Ellipse.prototype.destroy = function destroy() {
     this.element.remove();
@@ -1328,7 +1345,10 @@ Ellipse.prototype.updateShapeFromHandles = function updateShapeFromHandles(resiz
 Ellipse.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth;
+        strokeW = this._strokeWidth,
+        fillColor = this._fillColor,
+        fillOpacity = this._fillOpacity;
+
 
     var f = this._zoomFraction,
         x = this._x * f,
@@ -1341,7 +1361,9 @@ Ellipse.prototype.drawShape = function drawShape() {
                        'rx': radiusX,
                        'ry': radiusY,
                        'stroke': strokeColor,
-                       'stroke-width': strokeW});
+                       'stroke-width': strokeW,
+                       'fill': fillColor,
+                       'fill-opacity': fillOpacity});
     this.element.transform('r'+ this._rotation);
 
     if (this.isSelected()) {
@@ -1492,6 +1514,8 @@ CreateEllipse.prototype.startDrag = function startDrag(startX, startY) {
 
     var strokeColor = this.manager.getStrokeColor(),
         strokeWidth = this.manager.getStrokeWidth(),
+        fillColor = this.manager.getFillColor(),
+        fillOpacity = this.manager.getFillOpacity(),
         zoom = this.manager.getZoom();
 
     this.ellipse = new Ellipse({
@@ -1504,7 +1528,9 @@ CreateEllipse.prototype.startDrag = function startDrag(startX, startY) {
         'rotation': 0,
         'strokeWidth': strokeWidth,
         'zoom': zoom,
-        'strokeColor': strokeColor});
+        'strokeColor': strokeColor,
+        'fillColor': fillColor,
+        'fillOpacity': fillOpacity});
 };
 
 CreateEllipse.prototype.drag = function drag(dragX, dragY, shiftKey) {
@@ -2143,7 +2169,6 @@ ShapeManager.prototype.getFillOpacity = function getFillOpacity() {
 };
 
 ShapeManager.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
-    console.log(fillOpacity)
     var fillOpacity = parseFloat(fillOpacity, 10);
     this._fillOpacity = fillOpacity;
     var selected = this.getSelectedShapes();
@@ -2287,7 +2312,6 @@ ShapeManager.prototype.createShapeJson = function createShapeJson(jsonShape) {
                    'strokeColor': strokeColor,
                    'fillColor': fillColor,
                    'fillOpacity': fillOpacity};
-    console.log("sh.manager fillcolor "+fillColor);
     if (jsonShape.id) {
         options.id = jsonShape.id;
     }

--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -163,6 +163,10 @@ Line.prototype.getStrokeWidth = function getStrokeWidth() {
     return this._strokeWidth;
 };
 
+Line.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
 Line.prototype.destroy = function destroy() {
     this.element.remove();
     this.handles.remove();
@@ -537,6 +541,17 @@ var Rect = function Rect(options) {
     this._width = options.width;
     this._height = options.height;
     this._strokeColor = options.strokeColor;
+    console.log("Option.fuillColor "+options.fillColor);
+    if(options.fillColor){
+        this._fillColor = options.fillColor;
+    }else{
+        this._fillColor = "#ffffff";
+    }
+    if(options.fillOpacity){
+        this._fillOpacity = options.fillOpacity;
+    }else{
+        this._fillOpacity = 0.01;
+    }
     this._strokeWidth = options.strokeWidth || 2;
     this._selected = false;
     this._zoomFraction = 1;
@@ -546,8 +561,8 @@ var Rect = function Rect(options) {
     this.handle_wh = 6;
 
     this.element = this.paper.rect();
-    this.element.attr({'fill-opacity': 0.01,
-                       'fill': '#fff',
+    this.element.attr({'fill-opacity': this._fillOpacity,
+                       'fill': this._fillColor,
                        'cursor': 'pointer'});
 
     if (this.manager.canEdit) {
@@ -596,7 +611,9 @@ Rect.prototype.toJson = function toJson() {
         'width': this._width,
         'height': this._height,
         'strokeWidth': this._strokeWidth,
-        'strokeColor': this._strokeColor
+        'strokeColor': this._strokeColor,
+        'fillColor': this._fillColor,
+        'fillOpacity':this._fillOpacity
     };
     if (this._id) {
         rv.id = this._id;
@@ -722,6 +739,24 @@ Rect.prototype.getStrokeColor = function getStrokeColor() {
     return this._strokeColor;
 };
 
+Rect.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    this.drawShape();
+};
+
+Rect.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
+Rect.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    this._fillOpacity = fillOpacity;
+    this.drawShape();
+};
+
+Rect.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
+};
+
 Rect.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
     this._strokeWidth = strokeWidth;
     this.drawShape();
@@ -739,7 +774,9 @@ Rect.prototype.destroy = function destroy() {
 Rect.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        lineW = this._strokeWidth;
+        lineW = this._strokeWidth,
+        fillColor = this._fillColor,
+        fillOpacity = this._fillOpacity;
 
     var f = this._zoomFraction,
         x = this._x * f,
@@ -750,7 +787,9 @@ Rect.prototype.drawShape = function drawShape() {
     this.element.attr({'x':x, 'y':y,
                        'width':w, 'height':h,
                        'stroke': strokeColor,
-                       'stroke-width': lineW});
+                       'stroke-width': lineW,
+                       'fill': fillColor,
+                       'fill-opacity': fillOpacity});
 
     if (this.isSelected()) {
         this.element.toFront();
@@ -919,6 +958,8 @@ CreateRect.prototype.startDrag = function startDrag(startX, startY) {
 
     var strokeColor = this.manager.getStrokeColor(),
         strokeWidth = this.manager.getStrokeWidth(),
+        fillColor = this.manager.getFillColor(),
+        fillOpacity = this.manager.getFillOpacity(),
         zoom = this.manager.getZoom();
     // Also need to get strokeWidth and zoom/size etc.
 
@@ -934,7 +975,9 @@ CreateRect.prototype.startDrag = function startDrag(startX, startY) {
         'height': 0,
         'strokeWidth': strokeWidth,
         'zoom': zoom,
-        'strokeColor': strokeColor});
+        'strokeColor': strokeColor,
+        'fillColor': fillColor,
+        'fillOpacity': fillOpacity});
 };
 
 CreateRect.prototype.drag = function drag(dragX, dragY, shiftKey) {
@@ -1155,6 +1198,11 @@ Ellipse.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
 Ellipse.prototype.getStrokeWidth = function getStrokeWidth() {
     return this._strokeWidth;
 };
+
+Ellipse.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
 
 Ellipse.prototype.destroy = function destroy() {
     this.element.remove();
@@ -1626,6 +1674,10 @@ Polygon.prototype.setStrokeColor = function setStrokeColor(strokeColor) {
     this.drawShape();
 };
 
+Polygon.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
 Polygon.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
     this._strokeWidth = strokeWidth;
     this.drawShape();
@@ -1848,6 +1900,8 @@ var ShapeManager = function ShapeManager(elementId, width, height, options) {
     this._state = "SELECT";
     this._strokeColor = "#ff0000";
     this._strokeWidth = 2;
+    this._fillColor = "#ffffff";
+    this._fillOpacity = 0.01;
     this._orig_width = width;
     this._orig_height = height;
     this._zoom = 100;
@@ -2059,6 +2113,32 @@ ShapeManager.prototype.getStrokeColor = function getStrokeColor() {
     return this._strokeColor;
 };
 
+ShapeManager.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
+ShapeManager.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    var selected = this.getSelectedShapes();
+    for (var s=0; s<selected.length; s++) {
+        selected[s].setFillColor(fillColor);
+    }
+};
+
+ShapeManager.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
+};
+
+ShapeManager.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    console.log(fillOpacity)
+    var fillOpacity = parseFloat(fillOpacity, 10);
+    this._fillOpacity = fillOpacity;
+    var selected = this.getSelectedShapes();
+    for (var s=0; s<selected.length; s++) {
+        selected[s].setFillOpacity(fillOpacity);
+    }
+};
+
 ShapeManager.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
     strokeWidth = parseFloat(strokeWidth, 10);
     this._strokeWidth = strokeWidth;
@@ -2183,13 +2263,18 @@ ShapeManager.prototype.createShapeJson = function createShapeJson(jsonShape) {
     var s = jsonShape,
         newShape,
         strokeColor = s.strokeColor || this.getStrokeColor(),
+        fillColor = s.fillColor || this.getFillColor(),
+        fillOpacity = s.fillOpacity || this.getFillOpacity(),
         strokeWidth = s.strokeWidth || this.getStrokeWidth(),
         zoom = this.getZoom(),
         options = {'manager': this,
                    'paper': this.paper,
                    'strokeWidth': strokeWidth,
                    'zoom': zoom,
-                   'strokeColor': strokeColor};
+                   'strokeColor': strokeColor,
+                   'fillColor': fillColor,
+                   'fillOpacity': fillOpacity};
+    console.log("sh.manager fillcolor "+fillColor);
     if (jsonShape.id) {
         options.id = jsonShape.id;
     }
@@ -2372,7 +2457,9 @@ ShapeManager.prototype.selectAllShapes = function selectAllShapes(region) {
 ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
 
     var strokeColor,
-        strokeWidth;
+        strokeWidth,
+        fillColor,
+        fillOpacity;
 
     // Clear selected with silent:true, since we notify again below
     this.clearSelectedShapes(true);
@@ -2392,6 +2479,15 @@ ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
                     strokeColor = false;
                 }
             }
+            // for first shape, pick color
+            if (fillColor === undefined) {
+                fillColor = shape.getFillColor();
+            } else {
+                // for subsequent shapes, if colors don't match - set false
+                if (fillColor !== shape.getFillColor()) {
+                    fillColor = false;
+                }
+            }
             // for first shape, pick strokeWidth
             if (strokeWidth === undefined) {
                 strokeWidth = shape.getStrokeWidth();
@@ -2399,6 +2495,15 @@ ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
                 // for subsequent shapes, if colors don't match - set false
                 if (strokeWidth !== shape.getStrokeWidth()) {
                     strokeWidth = false;
+                }
+            }
+            // for first shape, pick fillOpacity
+            if (fillOpacity === undefined) {
+                fillOpacity = shape.getFillOpacity();
+            } else {
+                // for subsequent shapes, if colors don't match - set false
+                if (fillOpacity !== shape.getFillOpacity()) {
+                    fillOpacity = false;
                 }
             }
             shape.setSelected(true);
@@ -2409,6 +2514,12 @@ ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
     }
     if (strokeWidth) {
         this._strokeWidth = strokeWidth;
+    }
+    if (fillColor) {
+        this._fillColor = fillColor;
+    }
+    if (fillOpacity) {
+        this._fillOpacity = fillOpacity;
     }
     this.$el.trigger("change:selected");
 };

--- a/dist/js/shape-editor.js
+++ b/dist/js/shape-editor.js
@@ -541,17 +541,8 @@ var Rect = function Rect(options) {
     this._width = options.width;
     this._height = options.height;
     this._strokeColor = options.strokeColor;
-    console.log("Option.fuillColor "+options.fillColor);
-    if(options.fillColor){
-        this._fillColor = options.fillColor;
-    }else{
-        this._fillColor = "#ffffff";
-    }
-    if(options.fillOpacity){
-        this._fillOpacity = options.fillOpacity;
-    }else{
-        this._fillOpacity = 0.01;
-    }
+    this._fillColor = options.fillColor;
+    this._fillOpacity = options.fillOpacity;
     this._strokeWidth = options.strokeWidth || 2;
     this._selected = false;
     this._zoomFraction = 1;
@@ -1553,6 +1544,8 @@ var Polygon = function Polygon(options) {
 
     this._strokeColor = options.strokeColor;
     this._strokeWidth = options.strokeWidth || 2;
+    this._fillColor = options.fillColor;
+    this._fillOpacity = options.fillOpacity;
     this._selected = false;
     this._zoomFraction = 1;
     if (options.zoom) {
@@ -1561,8 +1554,8 @@ var Polygon = function Polygon(options) {
     this.handle_wh = 6;
 
     this.element = this.paper.path("");
-    this.element.attr({'fill-opacity': 0.01,
-                        'fill': '#fff',
+    this.element.attr({'fill-opacity': this._fillOpacity,
+                        'fill': this._fillColor,
                         'cursor': 'pointer'});
 
     if (this.manager.canEdit) {
@@ -1612,7 +1605,9 @@ Polygon.prototype.toJson = function toJson() {
         'type': "Polygon",
         'points': this._points,
         'strokeWidth': this._strokeWidth,
-        'strokeColor': this._strokeColor
+        'strokeColor': this._strokeColor,
+        'fillColor': this._fillColor,
+        'fillOpacity':this._fillOpacity
     };
     if (this._id) {
         rv.id = this._id;
@@ -1674,8 +1669,22 @@ Polygon.prototype.setStrokeColor = function setStrokeColor(strokeColor) {
     this.drawShape();
 };
 
+Polygon.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    this.drawShape();
+};
+
 Polygon.prototype.getFillColor = function getFillColor() {
     return this._fillColor;
+};
+
+Polygon.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    this._fillOpacity = fillOpacity;
+    this.drawShape();
+};
+
+Polygon.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
 };
 
 Polygon.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
@@ -1752,14 +1761,18 @@ Polygon.prototype.updateHandle = function updateHandle(handleIndex, x, y, shiftK
 Polygon.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth;
+        strokeW = this._strokeWidth,
+        fillColor = this._fillColor,
+        fillOpacity = this._fillOpacity;
 
     var f = this._zoomFraction;
     var path = this.getPath();
 
     this.element.attr({'path': path,
                        'stroke': strokeColor,
-                       'stroke-width': strokeW});
+                       'stroke-width': strokeW,
+                       'fill': fillColor,
+                       'fill-opacity': fillOpacity});
 
     if (this.isSelected()) {
         this.element.toFront();

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 		</div>
 
 		<div class="toolbar">
+			Stroke Color:<br />
 			<span style="background: #ff0000">
 				Red:
 				<input type="radio" name="strokeColor" checked value="#ff0000"/>
@@ -66,6 +67,29 @@
 		</div>
 
 		<div class="toolbar">
+			Fill Color:<br />
+			<span style="background: #ff0000">
+				Red:
+				<input type="radio" name="fillColor" checked value="#ff0000"/>
+			</span>
+			<br>
+			<span style="background: #00ff00">
+				Green:
+			<input type="radio" name="fillColor" value="#00ff00"/>
+			</span>
+			<br>
+			<span style="background: #ffff00">
+				Yellow:
+				<input type="radio" name="fillColor" value="#ffff00"/>
+			</span>
+			<br>
+			<span style="background: #ffffff">
+				White:
+				<input type="radio" name="fillColor" value="#ffffff"/>
+			</span>
+		</div>
+
+		<div class="toolbar">
 			Stroke Width:
 			<select name="strokeWidth">
 				<option value="0.25">0.25</option>
@@ -81,6 +105,21 @@
 				<option value="9">9</option>
 				<option value="10">10</option>
 				<option value="15">15</option>
+			</select>
+			<br />
+			Fill Opacity:
+			<select name="fillOpacity">
+				<option value="0.01">0.01</option>
+				<option value="0.1" selected="selected">0.1</option>
+				<option value="0.2">0.2</option>
+				<option value="0.3">0.3</option>
+				<option value="0.4">0.4</option>
+				<option value="0.5">0.5</option>
+				<option value="0.6">0.6</option>
+				<option value="0.7">0.7</option>
+				<option value="0.8">0.8</option>
+				<option value="0.9">0.9</option>
+				<option value="1">1</option>
 			</select>
 			<br />
 			Zoom: 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
 			.imageWrapper div, .imageWrapper img {
 				position: absolute;
 			}
+			#shapesCanvas {
+				background-color: black;
+			}
 		</style>
 	</head>
 

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -57,9 +57,21 @@ $(function() {
         shapeManager.setStrokeColor(strokeColor);
     });
 
+    $("input[name='fillColor']").click(function(){
+        var fillColor = $(this).val();
+        var fillOpacity = $("select[name='fillOpacity']").val();
+        shapeManager.setFillColor(fillColor);
+        shapeManager.setFillOpacity(fillOpacity);
+    });
+
     $("select[name='strokeWidth']").change(function(){
         var strokeWidth = $(this).val();
         shapeManager.setStrokeWidth(strokeWidth);
+    });
+
+    $("select[name='fillOpacity']").change(function(){
+        var fillOpacity = $(this).val();
+        shapeManager.setFillOpacity(fillOpacity);
     });
 
     var updateZoom = function updateZoom() {
@@ -150,8 +162,17 @@ $(function() {
         } else {
            $("input[name='strokeColor']").removeProp('checked');
         }
+        var fillColor = shapeManager.getFillColor();
+        if (fillColor) {
+          $("input[value='" + fillColor + "']").prop('checked', 'checked');
+        } else {
+           $("input[name='fillColor']").removeProp('checked');
+        }
         var strokeWidth = shapeManager.getStrokeWidth() || 1;
         $("select[name='strokeWidth']").val(strokeWidth);
+
+        var fillOpacity = shapeManager.getFillOpacity() || 0.01;
+        $("select[name='fillOpacity']").val(fillOpacity);
     });
 
     $("#shapesCanvas").bind("change:shape", function(event, shapes){

--- a/src/js/docs.js
+++ b/src/js/docs.js
@@ -158,13 +158,13 @@ $(function() {
     $("#shapesCanvas").bind("change:selected", function(){
         var strokeColor = shapeManager.getStrokeColor();
         if (strokeColor) {
-          $("input[value='" + strokeColor + "']").prop('checked', 'checked');
+          $("input[name='strokeColor'][value='" + strokeColor + "']").prop('checked', 'checked');
         } else {
            $("input[name='strokeColor']").removeProp('checked');
         }
         var fillColor = shapeManager.getFillColor();
         if (fillColor) {
-          $("input[value='" + fillColor + "']").prop('checked', 'checked');
+          $("input[name='fillColor'][value='" + fillColor + "']").prop('checked', 'checked');
         } else {
            $("input[name='fillColor']").removeProp('checked');
         }

--- a/src/js/shapeManager.js
+++ b/src/js/shapeManager.js
@@ -277,7 +277,6 @@ ShapeManager.prototype.getFillOpacity = function getFillOpacity() {
 };
 
 ShapeManager.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
-    console.log(fillOpacity)
     var fillOpacity = parseFloat(fillOpacity, 10);
     this._fillOpacity = fillOpacity;
     var selected = this.getSelectedShapes();
@@ -421,7 +420,6 @@ ShapeManager.prototype.createShapeJson = function createShapeJson(jsonShape) {
                    'strokeColor': strokeColor,
                    'fillColor': fillColor,
                    'fillOpacity': fillOpacity};
-    console.log("sh.manager fillcolor "+fillColor);
     if (jsonShape.id) {
         options.id = jsonShape.id;
     }

--- a/src/js/shapeManager.js
+++ b/src/js/shapeManager.js
@@ -277,7 +277,7 @@ ShapeManager.prototype.getFillOpacity = function getFillOpacity() {
 };
 
 ShapeManager.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
-    var fillOpacity = parseFloat(fillOpacity, 10);
+    fillOpacity = parseFloat(fillOpacity, 10);
     this._fillOpacity = fillOpacity;
     var selected = this.getSelectedShapes();
     for (var s=0; s<selected.length; s++) {

--- a/src/js/shapeManager.js
+++ b/src/js/shapeManager.js
@@ -47,6 +47,8 @@ var ShapeManager = function ShapeManager(elementId, width, height, options) {
     this._state = "SELECT";
     this._strokeColor = "#ff0000";
     this._strokeWidth = 2;
+    this._fillColor = "#ffffff";
+    this._fillOpacity = 0.01;
     this._orig_width = width;
     this._orig_height = height;
     this._zoom = 100;
@@ -258,6 +260,32 @@ ShapeManager.prototype.getStrokeColor = function getStrokeColor() {
     return this._strokeColor;
 };
 
+ShapeManager.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
+ShapeManager.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    var selected = this.getSelectedShapes();
+    for (var s=0; s<selected.length; s++) {
+        selected[s].setFillColor(fillColor);
+    }
+};
+
+ShapeManager.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
+};
+
+ShapeManager.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    console.log(fillOpacity)
+    var fillOpacity = parseFloat(fillOpacity, 10);
+    this._fillOpacity = fillOpacity;
+    var selected = this.getSelectedShapes();
+    for (var s=0; s<selected.length; s++) {
+        selected[s].setFillOpacity(fillOpacity);
+    }
+};
+
 ShapeManager.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
     strokeWidth = parseFloat(strokeWidth, 10);
     this._strokeWidth = strokeWidth;
@@ -382,13 +410,18 @@ ShapeManager.prototype.createShapeJson = function createShapeJson(jsonShape) {
     var s = jsonShape,
         newShape,
         strokeColor = s.strokeColor || this.getStrokeColor(),
+        fillColor = s.fillColor || this.getFillColor(),
+        fillOpacity = s.fillOpacity || this.getFillOpacity(),
         strokeWidth = s.strokeWidth || this.getStrokeWidth(),
         zoom = this.getZoom(),
         options = {'manager': this,
                    'paper': this.paper,
                    'strokeWidth': strokeWidth,
                    'zoom': zoom,
-                   'strokeColor': strokeColor};
+                   'strokeColor': strokeColor,
+                   'fillColor': fillColor,
+                   'fillOpacity': fillOpacity};
+    console.log("sh.manager fillcolor "+fillColor);
     if (jsonShape.id) {
         options.id = jsonShape.id;
     }
@@ -571,7 +604,9 @@ ShapeManager.prototype.selectAllShapes = function selectAllShapes(region) {
 ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
 
     var strokeColor,
-        strokeWidth;
+        strokeWidth,
+        fillColor,
+        fillOpacity;
 
     // Clear selected with silent:true, since we notify again below
     this.clearSelectedShapes(true);
@@ -591,6 +626,15 @@ ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
                     strokeColor = false;
                 }
             }
+            // for first shape, pick color
+            if (fillColor === undefined) {
+                fillColor = shape.getFillColor();
+            } else {
+                // for subsequent shapes, if colors don't match - set false
+                if (fillColor !== shape.getFillColor()) {
+                    fillColor = false;
+                }
+            }
             // for first shape, pick strokeWidth
             if (strokeWidth === undefined) {
                 strokeWidth = shape.getStrokeWidth();
@@ -598,6 +642,15 @@ ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
                 // for subsequent shapes, if colors don't match - set false
                 if (strokeWidth !== shape.getStrokeWidth()) {
                     strokeWidth = false;
+                }
+            }
+            // for first shape, pick fillOpacity
+            if (fillOpacity === undefined) {
+                fillOpacity = shape.getFillOpacity();
+            } else {
+                // for subsequent shapes, if colors don't match - set false
+                if (fillOpacity !== shape.getFillOpacity()) {
+                    fillOpacity = false;
                 }
             }
             shape.setSelected(true);
@@ -608,6 +661,12 @@ ShapeManager.prototype.selectShapes = function selectShapes(shapes) {
     }
     if (strokeWidth) {
         this._strokeWidth = strokeWidth;
+    }
+    if (fillColor) {
+        this._fillColor = fillColor;
+    }
+    if (fillOpacity) {
+        this._fillOpacity = fillOpacity;
     }
     this.$el.trigger("change:selected");
 };

--- a/src/js/shapes/ellipse.js
+++ b/src/js/shapes/ellipse.js
@@ -66,6 +66,8 @@ var Ellipse = function Ellipse(options) {
 
     this._strokeColor = options.strokeColor;
     this._strokeWidth = options.strokeWidth || 2;
+    this._fillColor = options.fillColor;
+    this._fillOpacity = options.fillOpacity;
     this._selected = false;
     this._zoomFraction = 1;
     if (options.zoom) {
@@ -74,8 +76,8 @@ var Ellipse = function Ellipse(options) {
     this.handle_wh = 6;
 
     this.element = this.paper.ellipse();
-    this.element.attr({'fill-opacity': 0.01,
-                        'fill': '#fff',
+    this.element.attr({'fill-opacity':  this._fillOpacity,
+                        'fill': this._fillColor,
                         'cursor': 'pointer'});
 
     // Drag handling of ellipse
@@ -132,7 +134,9 @@ Ellipse.prototype.toJson = function toJson() {
         'radiusY': this._radiusY,
         'rotation': this._rotation,
         'strokeWidth': this._strokeWidth,
-        'strokeColor': this._strokeColor
+        'strokeColor': this._strokeColor,
+        'fillColor': this._fillColor,
+        'fillOpacity':this._fillOpacity
     };
     if (this._id) {
         rv.id = this._id;
@@ -200,10 +204,23 @@ Ellipse.prototype.getStrokeWidth = function getStrokeWidth() {
     return this._strokeWidth;
 };
 
+Ellipse.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    this.drawShape();
+};
+
 Ellipse.prototype.getFillColor = function getFillColor() {
     return this._fillColor;
 };
 
+Ellipse.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    this._fillOpacity = fillOpacity;
+    this.drawShape();
+};
+
+Ellipse.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
+};
 
 Ellipse.prototype.destroy = function destroy() {
     this.element.remove();
@@ -338,7 +355,10 @@ Ellipse.prototype.updateShapeFromHandles = function updateShapeFromHandles(resiz
 Ellipse.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth;
+        strokeW = this._strokeWidth,
+        fillColor = this._fillColor,
+        fillOpacity = this._fillOpacity;
+
 
     var f = this._zoomFraction,
         x = this._x * f,
@@ -351,7 +371,9 @@ Ellipse.prototype.drawShape = function drawShape() {
                        'rx': radiusX,
                        'ry': radiusY,
                        'stroke': strokeColor,
-                       'stroke-width': strokeW});
+                       'stroke-width': strokeW,
+                       'fill': fillColor,
+                       'fill-opacity': fillOpacity});
     this.element.transform('r'+ this._rotation);
 
     if (this.isSelected()) {
@@ -502,6 +524,8 @@ CreateEllipse.prototype.startDrag = function startDrag(startX, startY) {
 
     var strokeColor = this.manager.getStrokeColor(),
         strokeWidth = this.manager.getStrokeWidth(),
+        fillColor = this.manager.getFillColor(),
+        fillOpacity = this.manager.getFillOpacity(),
         zoom = this.manager.getZoom();
 
     this.ellipse = new Ellipse({
@@ -514,7 +538,9 @@ CreateEllipse.prototype.startDrag = function startDrag(startX, startY) {
         'rotation': 0,
         'strokeWidth': strokeWidth,
         'zoom': zoom,
-        'strokeColor': strokeColor});
+        'strokeColor': strokeColor,
+        'fillColor': fillColor,
+        'fillOpacity': fillOpacity});
 };
 
 CreateEllipse.prototype.drag = function drag(dragX, dragY, shiftKey) {

--- a/src/js/shapes/ellipse.js
+++ b/src/js/shapes/ellipse.js
@@ -200,6 +200,11 @@ Ellipse.prototype.getStrokeWidth = function getStrokeWidth() {
     return this._strokeWidth;
 };
 
+Ellipse.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
+
 Ellipse.prototype.destroy = function destroy() {
     this.element.remove();
     this.handles.remove();

--- a/src/js/shapes/line.js
+++ b/src/js/shapes/line.js
@@ -183,6 +183,10 @@ Line.prototype.getStrokeWidth = function getStrokeWidth() {
     return this._strokeWidth;
 };
 
+Line.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
 Line.prototype.destroy = function destroy() {
     this.element.remove();
     this.handles.remove();

--- a/src/js/shapes/polygon.js
+++ b/src/js/shapes/polygon.js
@@ -155,6 +155,10 @@ Polygon.prototype.setStrokeColor = function setStrokeColor(strokeColor) {
     this.drawShape();
 };
 
+Polygon.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
 Polygon.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
     this._strokeWidth = strokeWidth;
     this.drawShape();

--- a/src/js/shapes/polygon.js
+++ b/src/js/shapes/polygon.js
@@ -34,6 +34,8 @@ var Polygon = function Polygon(options) {
 
     this._strokeColor = options.strokeColor;
     this._strokeWidth = options.strokeWidth || 2;
+    this._fillColor = options.fillColor;
+    this._fillOpacity = options.fillOpacity;
     this._selected = false;
     this._zoomFraction = 1;
     if (options.zoom) {
@@ -42,8 +44,8 @@ var Polygon = function Polygon(options) {
     this.handle_wh = 6;
 
     this.element = this.paper.path("");
-    this.element.attr({'fill-opacity': 0.01,
-                        'fill': '#fff',
+    this.element.attr({'fill-opacity': this._fillOpacity,
+                        'fill': this._fillColor,
                         'cursor': 'pointer'});
 
     if (this.manager.canEdit) {
@@ -93,7 +95,9 @@ Polygon.prototype.toJson = function toJson() {
         'type': "Polygon",
         'points': this._points,
         'strokeWidth': this._strokeWidth,
-        'strokeColor': this._strokeColor
+        'strokeColor': this._strokeColor,
+        'fillColor': this._fillColor,
+        'fillOpacity':this._fillOpacity
     };
     if (this._id) {
         rv.id = this._id;
@@ -155,8 +159,22 @@ Polygon.prototype.setStrokeColor = function setStrokeColor(strokeColor) {
     this.drawShape();
 };
 
+Polygon.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    this.drawShape();
+};
+
 Polygon.prototype.getFillColor = function getFillColor() {
     return this._fillColor;
+};
+
+Polygon.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    this._fillOpacity = fillOpacity;
+    this.drawShape();
+};
+
+Polygon.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
 };
 
 Polygon.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
@@ -233,14 +251,18 @@ Polygon.prototype.updateHandle = function updateHandle(handleIndex, x, y, shiftK
 Polygon.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        strokeW = this._strokeWidth;
+        strokeW = this._strokeWidth,
+        fillColor = this._fillColor,
+        fillOpacity = this._fillOpacity;
 
     var f = this._zoomFraction;
     var path = this.getPath();
 
     this.element.attr({'path': path,
                        'stroke': strokeColor,
-                       'stroke-width': strokeW});
+                       'stroke-width': strokeW,
+                       'fill': fillColor,
+                       'fill-opacity': fillOpacity});
 
     if (this.isSelected()) {
         this.element.toFront();

--- a/src/js/shapes/rect.js
+++ b/src/js/shapes/rect.js
@@ -42,17 +42,8 @@ var Rect = function Rect(options) {
     this._width = options.width;
     this._height = options.height;
     this._strokeColor = options.strokeColor;
-    console.log("Option.fuillColor "+options.fillColor);
-    if(options.fillColor){
-        this._fillColor = options.fillColor;
-    }else{
-        this._fillColor = "#ffffff";
-    }
-    if(options.fillOpacity){
-        this._fillOpacity = options.fillOpacity;
-    }else{
-        this._fillOpacity = 0.01;
-    }
+    this._fillColor = options.fillColor;
+    this._fillOpacity = options.fillOpacity;
     this._strokeWidth = options.strokeWidth || 2;
     this._selected = false;
     this._zoomFraction = 1;

--- a/src/js/shapes/rect.js
+++ b/src/js/shapes/rect.js
@@ -42,6 +42,17 @@ var Rect = function Rect(options) {
     this._width = options.width;
     this._height = options.height;
     this._strokeColor = options.strokeColor;
+    console.log("Option.fuillColor "+options.fillColor);
+    if(options.fillColor){
+        this._fillColor = options.fillColor;
+    }else{
+        this._fillColor = "#ffffff";
+    }
+    if(options.fillOpacity){
+        this._fillOpacity = options.fillOpacity;
+    }else{
+        this._fillOpacity = 0.01;
+    }
     this._strokeWidth = options.strokeWidth || 2;
     this._selected = false;
     this._zoomFraction = 1;
@@ -51,8 +62,8 @@ var Rect = function Rect(options) {
     this.handle_wh = 6;
 
     this.element = this.paper.rect();
-    this.element.attr({'fill-opacity': 0.01,
-                       'fill': '#fff',
+    this.element.attr({'fill-opacity': this._fillOpacity,
+                       'fill': this._fillColor,
                        'cursor': 'pointer'});
 
     if (this.manager.canEdit) {
@@ -101,7 +112,9 @@ Rect.prototype.toJson = function toJson() {
         'width': this._width,
         'height': this._height,
         'strokeWidth': this._strokeWidth,
-        'strokeColor': this._strokeColor
+        'strokeColor': this._strokeColor,
+        'fillColor': this._fillColor,
+        'fillOpacity':this._fillOpacity
     };
     if (this._id) {
         rv.id = this._id;
@@ -227,6 +240,24 @@ Rect.prototype.getStrokeColor = function getStrokeColor() {
     return this._strokeColor;
 };
 
+Rect.prototype.setFillColor = function setFillColor(fillColor) {
+    this._fillColor = fillColor;
+    this.drawShape();
+};
+
+Rect.prototype.getFillColor = function getFillColor() {
+    return this._fillColor;
+};
+
+Rect.prototype.setFillOpacity = function setFillOpacity(fillOpacity) {
+    this._fillOpacity = fillOpacity;
+    this.drawShape();
+};
+
+Rect.prototype.getFillOpacity = function getFillOpacity() {
+    return this._fillOpacity;
+};
+
 Rect.prototype.setStrokeWidth = function setStrokeWidth(strokeWidth) {
     this._strokeWidth = strokeWidth;
     this.drawShape();
@@ -244,7 +275,9 @@ Rect.prototype.destroy = function destroy() {
 Rect.prototype.drawShape = function drawShape() {
 
     var strokeColor = this._strokeColor,
-        lineW = this._strokeWidth;
+        lineW = this._strokeWidth,
+        fillColor = this._fillColor,
+        fillOpacity = this._fillOpacity;
 
     var f = this._zoomFraction,
         x = this._x * f,
@@ -255,7 +288,9 @@ Rect.prototype.drawShape = function drawShape() {
     this.element.attr({'x':x, 'y':y,
                        'width':w, 'height':h,
                        'stroke': strokeColor,
-                       'stroke-width': lineW});
+                       'stroke-width': lineW,
+                       'fill': fillColor,
+                       'fill-opacity': fillOpacity});
 
     if (this.isSelected()) {
         this.element.toFront();
@@ -424,6 +459,8 @@ CreateRect.prototype.startDrag = function startDrag(startX, startY) {
 
     var strokeColor = this.manager.getStrokeColor(),
         strokeWidth = this.manager.getStrokeWidth(),
+        fillColor = this.manager.getFillColor(),
+        fillOpacity = this.manager.getFillOpacity(),
         zoom = this.manager.getZoom();
     // Also need to get strokeWidth and zoom/size etc.
 
@@ -439,7 +476,9 @@ CreateRect.prototype.startDrag = function startDrag(startX, startY) {
         'height': 0,
         'strokeWidth': strokeWidth,
         'zoom': zoom,
-        'strokeColor': strokeColor});
+        'strokeColor': strokeColor,
+        'fillColor': fillColor,
+        'fillOpacity': fillOpacity});
 };
 
 CreateRect.prototype.drag = function drag(dragX, dragY, shiftKey) {


### PR DESCRIPTION
I added here the possibility to fill ROIs with a color, with a different opacity.
Everything seesm to work well, except one thing within the small GUI. 
1. Select one color for the stroke color
2. Select a different one for the fill color
3. When you click to draw the shape, the radio button changes automatically to match the exact same color in the GUI, but the two different colors have been taken into account for the drawing.

It does not affect the core functionnality but it is annyoing to have a GUI different from what it is drawn. I don't know what exactly happen and couldn't find any fix for now.

Edit: It is related to this issue https://github.com/ome/omero-figure/issues/485